### PR TITLE
[JBPM-9950] Creating k8s objects for deployment on internal OCP cluster

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,12 +14,18 @@ After some time, access the application via [http://localhost:8090/](http://loca
 
 ## Building the Website
 
+**IMPORTANT!** First thing you need to do is run a complete `mvn clean install` from the main 
+module (this project's root) to create the local maven repository.
+
+All the commands below must be run inside the module [`jbpm-bootstrap-service`](jbpm-bootstrap-service).
+
 ### Docker profile
 
 In this profile, just a regular docker image is built with the website in order to try it locally.
-To build using this profile, run the following command from this project's root:
+To build using this profile, run the following command:
 
 ````shell
+## remember to run inside jbpm-bootstrap-service
 $ mvn clean install -Pdocker
 ````
 
@@ -36,6 +42,7 @@ $ docker run --rm -it -p 8090:8090 jbpm/jbpm-bootstrap-service:latest
 This profile builds an image that exposes the secure `8443` port to be deployed on OpenShift online:
 
 ```
+## remember to run inside jbpm-bootstrap-service
 $ mvn clean install -Popenshift
 ```
 
@@ -59,6 +66,7 @@ The service can be exposed via an OpenShift Route or a Kubernetes Ingress by the
 To build it, run the following command:
 
 ```shell
+## remember to run inside jbpm-bootstrap-service
 $ mvn clean install -Popenshift_internal
 ```
 

--- a/README.md
+++ b/README.md
@@ -12,30 +12,99 @@ This command will build the application and the website image.
 
 After some time, access the application via [http://localhost:8090/](http://localhost:8090/).
 
-## CI/CD tooling
+## Building the Website
 
-This repository also contains script and resources to automate [start.jbpm.org](https://start.jbpm.org) releases.
+### Docker profile
+
+In this profile, just a regular docker image is built with the website in order to try it locally.
+To build using this profile, run the following command from this project's root:
+
+````shell
+$ mvn clean install -Pdocker
+````
+
+An image named `jbpm/jbpm-bootstrap-service:latest` will be available in your local registry.
+
+Run it with:
+
+```shell
+$ docker run --rm -it -p 8090:8090 jbpm/jbpm-bootstrap-service:latest
+```
+
+### OpenShift Online
+
+This profile builds an image that exposes the secure `8443` port to be deployed on OpenShift online:
+
+```
+$ mvn clean install -Popenshift
+```
+
+A valid certificate for the domain start.jbpm.org named `keystore.p12` must be placed on 
+[`src/main/resources`](jbpm-bootstrap-service/src/main/resources) folder in order to make this work.
+
+Run it with:
+
+```shell
+$ docker run --rm -it -p 8443:8443 jbpm/jbpm-bootstrap-service:latest
+```
+
+### OpenShift Managed
+
+For OpenShift Managed, the profile `openshift_internal` should be used.
+This profile exposes the service on port `8090` and creates all Kubernetes objects necessary
+to deploy the application on a managed Kubernetes or OpenShift cluster. It also works on Minikube.
+
+The service can be exposed via an OpenShift Route or a Kubernetes Ingress by the administrator.
+
+To build it, run the following command:
+
+```shell
+$ mvn clean install -Popenshift_internal
+```
+
+The image should be available in your local docker registry.
+
+Alternatively, if you're testing on minikube run `eval $(minikube docker-env)` before executing the `mvn` command.
+This way, the image will be built directly to your minikube registry.
+
+Use the following command to deploy the application on a Kubernetes/OpenShift cluster:
+
+```shell
+$ kubectl apply -f jbpm-bootstrap-service/target/classes/META-INF/jkube/kubernetes.yml -n <namespace>
+```
+
+This command will deploy a ConfigMap, a Service, a Deployment, and a PVC in the given namespace.
+
+#### Exposing the service on Minikube
+
+Simply run:
+
+````shell
+$ minikube service --url jbpm-bootstrap-service -n <namespace>
+````
+
+This will expose the created service as a NodePort in your machine. 
+The first address is the endpoint for the application.
 
 ### Bump Versions
 
-In order to bump versions from jBPM and/or Enterprise releases, clone the repository `start.jbpm.org`:
+There are two places to update as soon as a new version is released: the version mapping configuration file and the projects POM.
 
-```shell
-$ ls
-jbpm-bootstrap-kjar  jbpm-bootstrap-model  jbpm-bootstrap-service
-```
+#### Updating the Configuration File
 
-In the parent directory run the following script:
+All the versions used in the website interface are in the [`application.yml`](jbpm-bootstrap-service/src/main/resources/application.yml)
+file. Just add the next versions to this file.
 
-```shell
-$ python hack/bump-versions.py --community 7.45.0.Final --enterprise 7.9 --product 7.44.0.Final-redhat-00003
-```
+On OpenShift, this file is mounted as a `ConfigMap`. All you have to do is to update this file with the new version.
 
-**Note:** Replace the given versions with the actual ones
+On OpenShift Online, the file is being read from the classpath, so the image must be built again and pushed to the cluster
+after updating the file.
 
-The only required flag is **community**, since a product release is always followed up by a community release.
+#### Updating the application POM file
 
-You can now prepare a PR for each project with the required version.
+This project is a jBPM application, thus it uses the latest released version. 
+Just update it in the POM files from the [kjar](jbpm-bootstrap-kjar/pom.xml) and [service](jbpm-bootstrap-service/pom.xml) 
+projects as part of the bump process of all the modules of the KIE Group projects.
 
 #### Finding the correct version
 

--- a/jbpm-bootstrap-service/README.MD
+++ b/jbpm-bootstrap-service/README.MD
@@ -1,1 +1,5 @@
 # jBPM Bootstrap Service
+
+start.jbpm.org website project.
+
+See the main [README](../README.md) for more information.

--- a/jbpm-bootstrap-service/pom.xml
+++ b/jbpm-bootstrap-service/pom.xml
@@ -127,6 +127,14 @@
       </properties>
 
       <build>
+        <resources>
+          <resource>
+            <directory>src/main/jkube</directory>
+            <excludes>
+              <exclude>**/*.yaml</exclude>
+            </excludes>
+          </resource>
+        </resources>
         <plugins>
           <plugin>
             <groupId>org.eclipse.jkube</groupId>
@@ -191,6 +199,7 @@
       </build>
     </profile>
     <profile>
+      <!-- Profile dedicated to publish on OpenShift Online with owned certificates -->
       <id>openshift</id>
       <activation>
         <property>
@@ -205,12 +214,174 @@
       </properties>
 
       <build>
+        <resources>
+          <resource>
+            <directory>src/main/jkube</directory>
+            <excludes>
+              <exclude>**/*.yaml</exclude>
+            </excludes>
+          </resource>
+        </resources>
         <plugins>
           <plugin>
             <groupId>org.eclipse.jkube</groupId>
             <artifactId>kubernetes-maven-plugin</artifactId>
             <version>${jkube.version}</version>
             <configuration>
+              <verbose>false</verbose>
+              <images>
+                <image>
+                  <name>jbpm/${project.artifactId}:latest</name>
+                  <build>
+                    <from>registry.access.redhat.com/ubi8/openjdk-8:latest</from>
+                    <assembly>
+                      <targetDir>/</targetDir>
+                      <inline>
+                        <files>
+                          <file>
+                            <source>${project.build.directory}/${project.build.finalName}.${project.packaging}</source>
+                            <outputDirectory>deployments</outputDirectory>
+                            <destName>${project.build.finalName}.${project.packaging}</destName>
+                          </file>
+                          <file>
+                            <source>bootstrap-jbpm.xml</source>
+                            <outputDirectory>deployments</outputDirectory>
+                            <destName>bootstrap-jbpm.xml</destName>
+                          </file>
+                        </files>
+                        <fileSets>
+                          <fileSet>
+                            <directory>src/main/docker</directory>
+                            <outputDirectory>home/jboss/.m2</outputDirectory>
+                            <includes>
+                              <include>settings.xml</include>
+                            </includes>
+                          </fileSet>
+                          <fileSet>
+                            <directory>${local.maven.path}</directory>
+                            <outputDirectory>home/jboss/.m2/repository</outputDirectory>
+                          </fileSet>
+                        </fileSets>
+                      </inline>
+                      <user>jboss:jboss:jboss</user>
+                    </assembly>
+                    <runCmds>
+                      <!-- Narayana needs to write to the /deployments directory.
+                            OpenShift won't allow the container to run with root, thus not creating the dir.
+                           In this case we change the permissions of our directory to anyone in root group to write to it
+                        -->
+                      <run>
+                        chgrp -R 0 /deployments &amp;&amp; \
+                        chmod -R g=u /deployments
+                      </run>
+                    </runCmds>
+                    <user>jboss</user>
+                    <env>
+                      <JAVA_OPTIONS>-Dorg.kie.version=7.RELEASE -Dspring.profiles.active=${spring.profiles.active}</JAVA_OPTIONS>
+                    </env>
+                  </build>
+                </image>
+              </images>
+            </configuration>
+            <executions>
+              <execution>
+                <phase>install</phase>
+                <goals>
+                  <goal>resource</goal>
+                  <goal>build</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
+      <!-- Profile to deploy the application on a dedicated OpenShift, with Routes to manage the TLS communication -->
+      <id>openshift_internal</id>
+      <activation>
+        <property>
+          <name>openshift_internal</name>
+        </property>
+      </activation>
+
+      <properties>
+        <jkube.mode>Kubernetes</jkube.mode>
+        <local.maven.path>../jbpm-bootstrap-kjar/target/local-repository/maven</local.maven.path>
+        <spring.profiles.active>openshift_internal</spring.profiles.active>
+        <webPort>8090</webPort>
+        <jkube.generator.java-exec.webPort>${webPort}</jkube.generator.java-exec.webPort>
+      </properties>
+      <dependencies>
+        <dependency>
+          <groupId>org.springframework.boot</groupId>
+          <artifactId>spring-boot-starter-actuator</artifactId>
+        </dependency>
+      </dependencies>
+      <build>
+        <resources>
+          <resource>
+            <directory>src/main/resources</directory>
+            <excludes>
+              <!-- this file should be served by the CM, we remove it here to avoid configuration mismatch -->
+              <exclude>**/application.yml</exclude>
+              <!-- removes unused properties to not clash with our own properties -->
+              <exclude>**/*-dev.properties</exclude>
+              <exclude>**/*-docker.properties</exclude>
+              <exclude>**/*-openshift.properties</exclude>
+            </excludes>
+          </resource>
+        </resources>
+        <plugins>
+          <plugin>
+            <groupId>org.eclipse.jkube</groupId>
+            <artifactId>kubernetes-maven-plugin</artifactId>
+            <version>${jkube.version}</version>
+            <configuration>
+              <enricher>
+                <config>
+                  <jkube-service>
+                    <name>${project.artifactId}</name>
+                    <type>ClusterIP</type>
+                    <multiPort>true</multiPort>
+                  </jkube-service>
+                </config>
+              </enricher>
+              <resources>
+                <services>
+                  <service>
+                    <name>${project.artifactId}</name>
+                    <ports>
+                      <port>
+                        <name>web</name>
+                        <port>${webPort}</port>
+                        <protocol>tcp</protocol>
+                        <targetPort>${webPort}</targetPort>
+                      </port>
+                      <port>
+                        <name>jolokia</name>
+                        <port>8778</port>
+                        <protocol>tcp</protocol>
+                        <targetPort>8778</targetPort>
+                      </port>
+                      <port>
+                        <name>prometheus</name>
+                        <port>9779</port>
+                        <protocol>tcp</protocol>
+                        <targetPort>9779</targetPort>
+                      </port>
+                    </ports>
+                  </service>
+                </services>
+                <configMap>
+                  <name>${project.artifactId}</name>
+                  <entries>
+                    <entry>
+                      <file>src/main/resources/application.yml</file>
+                    </entry>
+                  </entries>
+                </configMap>
+              </resources>
               <verbose>false</verbose>
               <images>
                 <image>

--- a/jbpm-bootstrap-service/src/main/jkube/deployment.yaml
+++ b/jbpm-bootstrap-service/src/main/jkube/deployment.yaml
@@ -1,0 +1,46 @@
+metadata:
+  annotations:
+    configmap.jkube.io/update-on-change: ${project.artifactId}
+spec:
+  replicas: 1
+  strategy:
+    activeDeadlineSeconds: 21600
+    recreateParams:
+      timeoutSeconds: 600
+    resources: {}
+    type: Recreate
+  template:
+    spec:
+      containers:
+      - name: jbpm-bootstrap-service
+        imagePullPolicy: IfNotPresent
+        ports:
+          - containerPort: 8090
+            protocol: TCP
+          - containerPort: 8778
+            protocol: TCP
+          - containerPort: 9779
+            protocol: TCP
+        resources:
+          limits:
+            memory: 2Gi
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+        volumeMounts:
+          - mountPath: /deployments/data
+            name: data-volume
+          - mountPath: /deployments/config
+            name: config
+      restartPolicy: Always
+      securityContext: {}
+      terminationGracePeriodSeconds: 30
+      volumes:
+        - name: data-volume
+          persistentVolumeClaim:
+            claimName: start-jbpm-storage
+        - name: config
+          configMap:
+            name: ${project.artifactId}
+            items:
+            - key: application.yml
+              path: application.yml

--- a/jbpm-bootstrap-service/src/main/jkube/start-jbpm-storage-pvc.yaml
+++ b/jbpm-bootstrap-service/src/main/jkube/start-jbpm-storage-pvc.yaml
@@ -1,0 +1,6 @@
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 2Gi

--- a/jbpm-bootstrap-service/src/main/resources/application-openshift_internal.properties
+++ b/jbpm-bootstrap-service/src/main/resources/application-openshift_internal.properties
@@ -1,0 +1,52 @@
+#
+# https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#common-application-properties
+#
+#server configuration
+server.port.http=8090
+
+# second path needs to me mapped for Let'sEncrypt challange - .well-known/acme-challenge/xxxx
+spring.resources.static-locations=classpath:/static,file:/tmp
+
+cxf.path=/rest
+cxf.jaxrs.classes-scan=true
+cxf.jaxrs.classes-scan-packages=org.jbpm.bootstrap.service.rest
+
+#configure logging
+#logging.level.org.kie.server=DEBUG
+logging.level.org.reflections.Reflections=ERROR
+
+kieserver.serverId=bootstrap-jbpm
+kieserver.serverName=BootstrapJBPM
+kieserver.location=http://localhost:8090/rest/server
+
+#jbpm configuration
+jbpm.executor.enabled=true
+jbpm.executor.threadPoolSize=10
+jbpm.executor.retries=0
+
+kieserver.jbpm.enabled=true
+kieserver.jbpmui.enabled=true
+kieserver.drools.enabled=false
+kieserver.dmn.enabled=false
+kieserver.casemgmt.enabled=false
+kieserver.optaplanner.enabled=false
+
+# only required for jBPM
+#data source configuration
+spring.datasource.username=sa
+spring.datasource.password=sa
+spring.datasource.url=jdbc:h2:/deployments/data/start-jbpm
+spring.datasource.driver-class-name=org.h2.Driver
+
+#hibernate configuration
+spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.H2Dialect
+spring.jpa.properties.hibernate.show_sql=false
+spring.jpa.properties.hibernate.hbm2ddl.auto=update
+spring.jpa.properties.hibernate.connection.release_mode=after_transaction
+spring.jpa.hibernate.naming.physical-strategy=org.hibernate.boot.model.naming.PhysicalNamingStrategyStandardImpl
+
+#transaction manager configuration
+spring.jta.narayana.transaction-manager-id=1
+
+#thymeleaf configuration
+spring.thymeleaf.mode=LEGACYHTML5


### PR DESCRIPTION
Signed-off-by: Ricardo Zanini <zanini@redhat.com>

See: https://issues.redhat.com/browse/JBPM-9950

In this PR we add a new profile `openshift_internal` to generate the objects needed for Kubernetes/OpenShift deployment with external configuration enabled.